### PR TITLE
Legacyiaccessiblepattern full interface definition

### DIFF
--- a/pkg/win32/api/user-interface/windows-accesibility-features/iuiautomationlegacyiaccessiblepattern.go
+++ b/pkg/win32/api/user-interface/windows-accesibility-features/iuiautomationlegacyiaccessiblepattern.go
@@ -15,7 +15,31 @@ type IUIAutomationLegacyIAccessiblePattern struct {
 
 type IUIAutomationLegacyIAccessiblePatternVtbl struct {
 	ole.IUnknownVtbl
-	SetValue uintptr
+
+	DoDefaultAction             uintptr
+	Get_CachedChildId           uintptr
+	SetValue                    uintptr
+	Get_CachedDefaultAction     uintptr
+	Get_CachedDescription       uintptr
+	Get_CachedHelp              uintptr
+	Get_CachedKeyboardShortcut  uintptr
+	Get_CachedName              uintptr
+	Get_CachedRole              uintptr
+	Get_CachedState             uintptr
+	Get_CachedValue             uintptr
+	Get_CurrentChildId          uintptr
+	Get_CurrentDefaultAction    uintptr
+	Get_CurrentDescription      uintptr
+	Get_CurrentHelp             uintptr
+	Get_CurrentKeyboardShortcut uintptr
+	Get_CurrentName             uintptr
+	Get_CurrentRole             uintptr
+	Get_CurrentState            uintptr
+	Get_CurrentValue            uintptr
+	GetCachedSelection          uintptr
+	GetCurrentSelection         uintptr
+	GetIAccessible              uintptr
+	Select                      uintptr
 }
 
 // https://github.com/mmarquee/ui-automation/blob/ec43c1449b11b5d0f3fd313367e242c6ce456bd9/src/main/java/mmarquee/uiautomation/IUIAutomationLegacyIAccessiblePattern.java
@@ -30,7 +54,6 @@ func (pat *IUIAutomationLegacyIAccessiblePattern) VTable() *IUIAutomationLegacyI
 // 	LPCWSTR szValue
 // );
 func (pat *IUIAutomationLegacyIAccessiblePattern) SetValue(value string) error {
-
 	szValue, err := syscall.UTF16PtrFromString(value)
 	if err != nil {
 		return err

--- a/pkg/win32/api/user-interface/windows-accesibility-features/uiautomation.go
+++ b/pkg/win32/api/user-interface/windows-accesibility-features/uiautomation.go
@@ -202,6 +202,6 @@ func getLegacyIAccessiblePattern(element *wa.IUIAutomationElement) (*IUIAutomati
 		logging.Error(err)
 		return nil, err
 	}
-	logging.Info("found interface dispatcher for value pattern")
+	logging.Info("found interface dispatcher for LegacyIAccessible pattern")
 	return (*IUIAutomationLegacyIAccessiblePattern)(unsafe.Pointer(disp)), nil
 }

--- a/pkg/win32/ux/ux.go
+++ b/pkg/win32/ux/ux.go
@@ -23,6 +23,7 @@ const (
 	CHECKBOX = "checkbox"
 	EDIT     = "edit"
 	PANE     = "pane"
+	COMBOBOX = "combobox"
 
 	windowId   = wa.UIA_WindowControlTypeId
 	buttonId   = wa.UIA_ButtonControlTypeId
@@ -35,6 +36,7 @@ const (
 	checkboxId = wa.UIA_CheckBoxControlTypeId
 	editId     = wa.UIA_EditControlTypeId
 	paneId     = wa.UIA_PaneControlTypeId
+	comboboxId = wa.UIA_ComboBoxControlTypeId
 )
 
 var elementTypes map[string]int64 = map[string]int64{
@@ -48,7 +50,8 @@ var elementTypes map[string]int64 = map[string]int64{
 	MENUITEM: menuitemId,
 	CHECKBOX: checkboxId,
 	EDIT:     editId,
-	PANE:     paneId}
+	PANE:     paneId,
+	COMBOBOX: comboboxId}
 
 type UXElement struct {
 	name        string


### PR DESCRIPTION
There was a bug using legacy i accessible pattern  due to missing methods on interface definition. This PR solves this problem and allows to execute SetValue properly